### PR TITLE
make group_by optional in the groups embeddable schema

### DIFF
--- a/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/fixtures/schema_snapshot.json
+++ b/src/platform/plugins/shared/dashboard/test/scout_oas_schema/api/fixtures/schema_snapshot.json
@@ -154,10 +154,7 @@
         "type": "string"
        }
       },
-      "additionalProperties": false,
-      "required": [
-       "group_by"
-      ]
+      "additionalProperties": false
      },
      "overview_mode": {
       "type": "string",

--- a/x-pack/solutions/observability/plugins/slo/common/embeddables/overview/transforms/transform_group_overview_out.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/embeddables/overview/transforms/transform_group_overview_out.ts
@@ -50,7 +50,7 @@ function transformGroupFilters(
 
   return {
     ...state,
-    group_by: groupBy,
+    group_by: groupBy ?? 'status',
     ...(filters ? { filters: fromStoredFilters(groupFilters.filters) } : {}),
     ...(kqlQuery ? { kql_query: kqlQuery } : {}),
   };

--- a/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/group_view/slo_group_filters.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/group_view/slo_group_filters.tsx
@@ -101,8 +101,9 @@ export function SloGroupFilters({ selectedFilters, onSelected }: Props) {
   const { dataView } = useCreateDataView({
     indexPatternString: SUMMARY_DESTINATION_INDEX_NAME,
   });
-  const [selectedGroupBy, setSelectedGroupBy] =
-    useState<GroupBy>(selectedFilters.group_by) ?? 'status';
+  const [selectedGroupBy, setSelectedGroupBy] = useState<GroupBy>(
+    selectedFilters.group_by ?? 'status'
+  );
   const [filters, setFilters] = useState<Filter[]>(() =>
     ensureFiltersHaveState(toStoredFilters(selectedFilters.filters) ?? [])
   );

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.test.ts
@@ -135,6 +135,22 @@ describe('schema validation', () => {
 
       expect(() => overviewEmbeddableSchema.validate(minimalState)).not.toThrow();
     });
+
+    it('should validate group overview state with empty group_filters or missing group_by', () => {
+      const stateWithEmptyGroupFilters = {
+        group_filters: {},
+        overview_mode: 'groups' as const,
+      };
+      expect(() => overviewEmbeddableSchema.validate(stateWithEmptyGroupFilters)).not.toThrow();
+
+      const stateWithGroupFiltersWithoutGroupBy = {
+        group_filters: { groups: ['healthy'] },
+        overview_mode: 'groups' as const,
+      };
+      expect(() =>
+        overviewEmbeddableSchema.validate(stateWithGroupFiltersWithoutGroupBy)
+      ).not.toThrow();
+    });
   });
 
   it('should validate single overview state with optional fields omitted', () => {

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.ts
@@ -42,7 +42,7 @@ const groupBySchema = schema.oneOf([
 const GroupOverviewCustomSchema = schema.object({
   group_filters: schema.maybe(
     schema.object({
-      group_by: groupBySchema,
+      group_by: schema.maybe(groupBySchema),
       groups: schema.maybe(schema.arrayOf(schema.string())),
       filters: schema.maybe(schema.arrayOf(asCodeFilterSchema)),
       kql_query: schema.maybe(schema.string()),


### PR DESCRIPTION
## Summary

**Issue 1**

The `group_filters` object is itself optional (schema.maybe(...)). Inside it, `groups`, `filters`, and `kql_query` are all optional too. But `group_by` was required once you provided group_filters. That means if you wanted to create a group SLO embeddable via the API with just a KQL filter:

  {
    "group_filters": {
      "kql_query": "slo.name: \"my-slo\""
    },
    "overview_mode": "groups"
  }

  ...it would fail validation because group_by is missing, even though both the UI and the transform layer already
  default it to 'status' when absent. Making group_by optional in the schema aligns validation with the actual semantics: 'status' is the default, and the consumer code already handles the absent case.

**Issue 2**
The schema uses schema.oneOf([single, groups]) from @kbn/config-schema. Its UnionType.handleError always reports errors from ALL variants, producing misleading messages like [0.slo_id]: expected value of type [string] but got [undefined] even in groups mode.

## Acceptance criteria
- Make group_by optional in GroupOverviewCustomSchema
- Fix useState default precedence in slo_group_filters.tsx
- Default group_by to 'status' in transform_group_overview_out.ts
- Switch schema.oneOf to schema.discriminatedUnion('overview_mode', ...) in getOverviewEmbeddableSchema
- Adapt OAS tests