### PR TITLE
UI fix for empty panel for non-existent SLO id

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/slo_overview.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/slo_overview.tsx
@@ -69,19 +69,7 @@ export function SloOverview({ sloId, sloInstanceId, remoteName, reloadSubject }:
     refetch();
   }, [lastRefreshTime, refetch]);
 
-  const isSloNotFound = !isLoading && slo === undefined;
-
-  if (isRefetching || isLoading || !slo) {
-    return (
-      <LoadingContainer>
-        <LoadingContent>
-          <EuiLoadingChart />
-        </LoadingContent>
-      </LoadingContainer>
-    );
-  }
-
-  if (isSloNotFound) {
+  if (!isLoading && !isRefetching && slo === undefined) {
     return (
       <LoadingContainer>
         <LoadingContent>
@@ -89,6 +77,16 @@ export function SloOverview({ sloId, sloInstanceId, remoteName, reloadSubject }:
             defaultMessage:
               'The SLO has been deleted. You can safely delete the widget from the dashboard.',
           })}
+        </LoadingContent>
+      </LoadingContainer>
+    );
+  }
+
+  if (isRefetching || isLoading || !slo) {
+    return (
+      <LoadingContainer>
+        <LoadingContent>
+          <EuiLoadingChart />
         </LoadingContent>
       </LoadingContainer>
     );


### PR DESCRIPTION
## Summary

When creating a dashboard panel via Dev Tools with a Single SLO Overview embeddable pointing to a non-existent slo_id, the panel shows an empty loading spinner indefinitely instead of the "SLO has been deleted" message.

```
POST kbn:/api/dashboards/dashboard?apiVersion=1
{
      "title": "Single SLO dashboad with invalid slo_id",
      "panels": [
        {
          "config": {
              "slo_id": "1111",
              "overview_mode": "single"
           },
           "grid": {
              "x": 1,
              "y": 0
           },
           "type": "SLO_EMBEDDABLE"
          }
      ]
}
```


## Root cause
In slo_overview.tsx, the "not found" check was unreachable dead code. The loading guard `if (isRefetching || isLoading || !slo)` always matched first because `!slo` is true when the SLO is undefined (not found). This returned the spinner before the isSloNotFound check could execute.

## Fix

Reordered the conditions so the "not found" check (`!isLoading && !isRefetching && slo === undefined`) runs before the loading spinner guard. Now when loading completes and the SLO does not exist, the user sees the proper message: "The SLO has been deleted. You can safely delete the widget from the dashboard."

### Before
<img width="500" height="536" alt="before" src="https://github.com/user-attachments/assets/f89f8589-6d9c-436a-8bd3-24f2107ed5f4" />


### After
<img width="500" height="464" alt="after" src="https://github.com/user-attachments/assets/04d76f60-5ec3-4e86-9d92-b98f88c6f268" />
