### PR TITLE
Drop showShowAllGroupByInstances from schema

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/common/embeddables/overview/transforms/transform_single_overview_out.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/embeddables/overview/transforms/transform_single_overview_out.test.ts
@@ -47,4 +47,54 @@ describe('transformSingleOverviewOut', () => {
       }
     `);
   });
+
+  it('should drop slo_instance_id for legacy non-grouped SLOs with sloInstanceId "*" and showAllGroupByInstances false', () => {
+    expect(
+      transformSingleOverviewOut({
+        sloId: 'non-grouped-slo-id',
+        sloInstanceId: '*',
+        overviewMode: 'single',
+        showAllGroupByInstances: false,
+      } as unknown as OverviewEmbeddableState)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "overview_mode": "single",
+        "slo_id": "non-grouped-slo-id",
+      }
+    `);
+  });
+
+  it('should keep slo_instance_id for legacy grouped SLOs with sloInstanceId "*" and showAllGroupByInstances true', () => {
+    expect(
+      transformSingleOverviewOut({
+        sloId: 'grouped-slo-id',
+        sloInstanceId: '*',
+        overviewMode: 'single',
+        showAllGroupByInstances: true,
+      } as unknown as OverviewEmbeddableState)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "overview_mode": "single",
+        "slo_id": "grouped-slo-id",
+        "slo_instance_id": "*",
+      }
+    `);
+  });
+
+  it('should keep slo_instance_id for legacy grouped SLOs with a specific instance', () => {
+    expect(
+      transformSingleOverviewOut({
+        sloId: 'grouped-slo-id',
+        sloInstanceId: 'specific-instance-id',
+        overviewMode: 'single',
+        showAllGroupByInstances: false,
+      } as unknown as OverviewEmbeddableState)
+    ).toMatchInlineSnapshot(`
+      Object {
+        "overview_mode": "single",
+        "slo_id": "grouped-slo-id",
+        "slo_instance_id": "specific-instance-id",
+      }
+    `);
+  });
 });

--- a/x-pack/solutions/observability/plugins/slo/common/embeddables/overview/transforms/transform_single_overview_out.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/embeddables/overview/transforms/transform_single_overview_out.test.ts
@@ -23,7 +23,6 @@ describe('transformSingleOverviewOut', () => {
       Object {
         "overview_mode": "single",
         "remote_name": "legacy-remote",
-        "show_all_group_by_instances": true,
         "slo_id": "legacy-slo-id",
         "slo_instance_id": "legacy-instance-id",
         "title": "Test Title",

--- a/x-pack/solutions/observability/plugins/slo/common/embeddables/overview/transforms/transform_single_overview_out.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/embeddables/overview/transforms/transform_single_overview_out.ts
@@ -30,10 +30,8 @@ export function transformSingleOverviewOut(
     remoteName: legacyRemoteName,
     overviewMode: legacyOverviewMode,
     showAllGroupByInstances: _legacyShowAll,
-    show_all_group_by_instances: _showAll,
     ...state
-  } = storedState as SingleOverviewCustomState &
-    LegacySingleOverviewState & { show_all_group_by_instances?: boolean };
+  } = storedState as SingleOverviewCustomState & LegacySingleOverviewState;
 
   const sloId = state.slo_id ?? legacySloId;
   const sloInstanceId = state.slo_instance_id ?? legacySloInstanceId;

--- a/x-pack/solutions/observability/plugins/slo/common/embeddables/overview/transforms/transform_single_overview_out.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/embeddables/overview/transforms/transform_single_overview_out.ts
@@ -5,6 +5,7 @@
  * 2.0.
  */
 
+import { ALL_VALUE } from '@kbn/slo-schema';
 import type {
   OverviewEmbeddableState,
   SingleOverviewCustomState,
@@ -29,7 +30,7 @@ export function transformSingleOverviewOut(
     sloInstanceId: legacySloInstanceId,
     remoteName: legacyRemoteName,
     overviewMode: legacyOverviewMode,
-    showAllGroupByInstances: _legacyShowAll,
+    showAllGroupByInstances: legacyShowAll,
     ...state
   } = storedState as SingleOverviewCustomState & LegacySingleOverviewState;
 
@@ -37,10 +38,16 @@ export function transformSingleOverviewOut(
   const sloInstanceId = state.slo_instance_id ?? legacySloInstanceId;
   const remoteName = state.remote_name ?? legacyRemoteName;
   const overviewMode = state.overview_mode ?? legacyOverviewMode;
+
+  // Legacy non-grouped SLOs stored sloInstanceId: "*" with showAllGroupByInstances: false.
+  // Drop slo_instance_id in that case to avoid rendering all-instances view for a non-grouped SLO.
+  const shouldIncludeInstanceId =
+    sloInstanceId && (sloInstanceId !== ALL_VALUE || legacyShowAll === true);
+
   return {
     ...state,
     ...(sloId ? { slo_id: sloId } : {}),
-    ...(sloInstanceId ? { slo_instance_id: sloInstanceId } : {}),
+    ...(shouldIncludeInstanceId ? { slo_instance_id: sloInstanceId } : {}),
     ...(remoteName ? { remote_name: remoteName } : {}),
     ...(overviewMode ? { overview_mode: overviewMode } : {}),
   };

--- a/x-pack/solutions/observability/plugins/slo/common/embeddables/overview/transforms/transform_single_overview_out.ts
+++ b/x-pack/solutions/observability/plugins/slo/common/embeddables/overview/transforms/transform_single_overview_out.ts
@@ -29,21 +29,21 @@ export function transformSingleOverviewOut(
     sloInstanceId: legacySloInstanceId,
     remoteName: legacyRemoteName,
     overviewMode: legacyOverviewMode,
-    showAllGroupByInstances: legacyShowAll,
+    showAllGroupByInstances: _legacyShowAll,
+    show_all_group_by_instances: _showAll,
     ...state
-  } = storedState as SingleOverviewCustomState & LegacySingleOverviewState;
+  } = storedState as SingleOverviewCustomState &
+    LegacySingleOverviewState & { show_all_group_by_instances?: boolean };
 
   const sloId = state.slo_id ?? legacySloId;
   const sloInstanceId = state.slo_instance_id ?? legacySloInstanceId;
   const remoteName = state.remote_name ?? legacyRemoteName;
   const overviewMode = state.overview_mode ?? legacyOverviewMode;
-  const showAllGroupByInstances = state.show_all_group_by_instances ?? legacyShowAll;
   return {
     ...state,
     ...(sloId ? { slo_id: sloId } : {}),
     ...(sloInstanceId ? { slo_instance_id: sloInstanceId } : {}),
     ...(remoteName ? { remote_name: remoteName } : {}),
     ...(overviewMode ? { overview_mode: overviewMode } : {}),
-    ...(showAllGroupByInstances ? { show_all_group_by_instances: showAllGroupByInstances } : {}),
   };
 }

--- a/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/slo_configuration.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/slo_configuration.tsx
@@ -58,7 +58,6 @@ function SingleSloConfiguration({ onCreate, onCancel }: SingleConfigurationProps
   >();
   const [selectedInstanceId, setSelectedInstanceId] = useState<string | undefined>(ALL_VALUE);
   const [hasError, setHasError] = useState(false);
-  const showAllGroupByInstances = selectedInstanceId === ALL_VALUE;
 
   const hasGroupBy = selectedSloDefinition?.groupBy
     ? selectedSloDefinition.groupBy.length > 0 && !selectedSloDefinition.groupBy.includes(ALL_VALUE)
@@ -73,9 +72,8 @@ function SingleSloConfiguration({ onCreate, onCancel }: SingleConfigurationProps
     const remoteName: string | undefined = selectedSloDefinition?.remote?.remoteName;
 
     onCreate({
-      show_all_group_by_instances: showAllGroupByInstances,
       slo_id: selectedSloDefinition.id,
-      slo_instance_id: selectedInstanceId ?? ALL_VALUE,
+      slo_instance_id: hasGroupBy ? selectedInstanceId ?? ALL_VALUE : undefined,
       remote_name: remoteName,
       overview_mode: 'single',
     });

--- a/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/slo_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/slo_embeddable_factory.tsx
@@ -13,6 +13,7 @@ import type { EmbeddableFactory } from '@kbn/embeddable-plugin/public';
 import { i18n } from '@kbn/i18n';
 import { EuiThemeProvider } from '@kbn/kibana-react-plugin/common';
 import { KibanaContextProvider } from '@kbn/kibana-react-plugin/public';
+import { ALL_VALUE } from '@kbn/slo-schema';
 import {
   fetch$,
   initializeStateManager,
@@ -82,7 +83,6 @@ export const getOverviewEmbeddableFactory = ({
       slo_id: '',
       slo_instance_id: undefined,
       remote_name: undefined,
-      show_all_group_by_instances: undefined,
     });
     const groupSloManager = initializeStateManager<Omit<GroupOverviewCustomState, 'overview_mode'>>(
       state as GroupOverviewCustomState,
@@ -133,7 +133,6 @@ export const getOverviewEmbeddableFactory = ({
         slo_id: 'referenceEquality',
         slo_instance_id: 'referenceEquality',
         group_filters: 'referenceEquality',
-        show_all_group_by_instances: 'referenceEquality',
         remote_name: 'referenceEquality',
         overview_mode: 'referenceEquality',
         ...titleComparators,
@@ -195,21 +194,14 @@ export const getOverviewEmbeddableFactory = ({
     return {
       api,
       Component: () => {
-        const [
-          sloId,
-          sloInstanceId,
-          showAllGroupByInstances,
-          overviewMode,
-          groupFilters,
-          remoteName,
-        ] = useBatchedPublishingSubjects(
-          singleSloManager.api.sloId$,
-          singleSloManager.api.sloInstanceId$,
-          singleSloManager.api.showAllGroupByInstances$,
-          overviewMode$,
-          groupSloManager.api.groupFilters$,
-          singleSloManager.api.remoteName$
-        );
+        const [sloId, sloInstanceId, overviewMode, groupFilters, remoteName] =
+          useBatchedPublishingSubjects(
+            singleSloManager.api.sloId$,
+            singleSloManager.api.sloInstanceId$,
+            overviewMode$,
+            groupSloManager.api.groupFilters$,
+            singleSloManager.api.remoteName$
+          );
 
         useEffect(() => {
           return () => {
@@ -259,7 +251,6 @@ export const getOverviewEmbeddableFactory = ({
                 sloInstanceId={sloInstanceId}
                 reloadSubject={reload$}
                 remoteName={remoteName}
-                showAllGroupByInstances={showAllGroupByInstances}
               />
             );
           }
@@ -281,7 +272,7 @@ export const getOverviewEmbeddableFactory = ({
                 <QueryClientProvider client={queryClient}>
                   {overviewMode === 'groups' ? (
                     renderOverview()
-                  ) : showAllGroupByInstances ? (
+                  ) : sloInstanceId === ALL_VALUE ? (
                     <div
                       data-test-subj="sloSingleOverviewPanel"
                       data-shared-item=""

--- a/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/slo_overview.tsx
+++ b/x-pack/solutions/observability/plugins/slo/public/embeddable/slo/overview/slo_overview.tsx
@@ -24,7 +24,6 @@ interface Props {
   sloId: string | undefined;
   sloInstanceId: string | undefined;
   remoteName?: string;
-  showAllGroupByInstances?: boolean;
   reloadSubject?: Subject<boolean>;
 }
 

--- a/x-pack/solutions/observability/plugins/slo/public/plugin.ts
+++ b/x-pack/solutions/observability/plugins/slo/public/plugin.ts
@@ -31,6 +31,7 @@ import type {
   OverviewEmbeddableState,
   SingleOverviewCustomState,
 } from '../common/embeddables/overview/types';
+import { ALL_VALUE } from '@kbn/slo-schema';
 import { SloDetailsLocatorDefinition } from './locators/slo_details';
 import { SloDetailsHistoryLocatorDefinition } from './locators/slo_details_history';
 import { SloEditLocatorDefinition } from './locators/slo_edit';
@@ -140,7 +141,7 @@ export class SLOPlugin
           SLO_OVERVIEW_EMBEDDABLE_ID,
           (serializedState?: OverviewEmbeddableState) => {
             if (
-              (serializedState as SingleOverviewCustomState)?.show_all_group_by_instances ||
+              (serializedState as SingleOverviewCustomState)?.slo_instance_id === ALL_VALUE ||
               (serializedState as GroupOverviewCustomState)?.group_filters
             ) {
               return { placementSettings: { width: 24, height: 8 } };

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.test.ts
@@ -17,7 +17,6 @@ describe('schema validation', () => {
         slo_id: 'test-slo-id',
         slo_instance_id: 'test-instance-id',
         remote_name: 'remote-1',
-        show_all_group_by_instances: true,
         overview_mode: 'single' as const,
         title: 'Test Title',
         hide_title: false,
@@ -29,7 +28,6 @@ describe('schema validation', () => {
         slo_id: 'test-slo-id',
         slo_instance_id: 'test-instance-id',
         remote_name: 'remote-1',
-        show_all_group_by_instances: true,
         overview_mode: 'single',
       });
     });
@@ -233,7 +231,7 @@ describe('schema validation', () => {
     const stateWithOnlyRequiredFields = {
       slo_id: 'test-slo-id',
       overview_mode: 'single' as const,
-      // slo_instance_id, remote_name, show_all_group_by_instances are all optional
+      // slo_instance_id, remote_name are all optional
     };
 
     expect(() => overviewEmbeddableSchema.validate(stateWithOnlyRequiredFields)).not.toThrow();

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.ts
@@ -29,7 +29,6 @@ const SingleOverviewCustomSchema = schema.object({
       meta: { description: 'The name of the remote SLO' },
     })
   ),
-  show_all_group_by_instances: schema.maybe(schema.boolean()),
   overview_mode: schema.literal('single'),
 });
 


### PR DESCRIPTION
## Summary

`showAllGroupByInstances` is currently stored in Overview panel's saved state and it is used to decide if it should render `SloCardChartList` or `SloOverview`. The rendering decision can now be driven by `slo_instance_id` and thus show_all_group_by_instances should not be added to the schema at all. We should make sure that legacy single overview panels still work as expected.

### Single Overview legacy saved state:

| Scenario                                           | overviewMode | showAllGroupByInstances | sloId                                   | sloInstanceId                          |
|----------------------------------------------------|-------------|--------------------------|-------------------------------------------|----------------------------------------|
| Single SLO without group by                       | single      | false                    | 14f7f371-666e-4fde-ad52-c7d9fd625df0      | *                                      |
| Single SLO with group by (specific instance)      | single      | false                    | 92a43b2e-00ec-4a63-a491-9f2cab772d08      | 40e65fa6-e778-4b70-b9f2-0cff33936447   |
| Single SLO with group by (show all instances)     | single      | true                     | 92a43b2e-00ec-4a63-a491-9f2cab772d08      | *                                      |

### Rendering decision
The rendering decision can now be driven by `slo_instance_id`:
- slo_instance_id === "*" → show all group-by instances (SloCardChartList)
- slo_instance_id === INSTANCE_ID → show single instance (SloOverview)
- slo_instance_id absent → show single card (SloOverview)

For **new panels**, the configuration flyout should only set slo_instance_id to `"*"` when the SLO has `group_by` and the user selects `all instances`. For non-grouped SLOs, slo_instance_id should be left undefined.

**Legacy dashboard compatibility**
The transform should handle the migration, with special attention to how slo_instance_id is derived (dropped or not):

| Scenario                          | Stored sloInstanceId | Stored showAllGroupByInstances | Transform output            | Rendered view |
|-----------------------------------|----------------------|-----------------|----------------------------|---------------|
| Non-grouped SLO                   | *                    | false           | slo_instance_id dropped    | Single card   |
| Grouped SLO, specific instance    | INSTANCE_ID               | false           | slo_instance_id: INSTANCE_ID    | Single card   |
| Grouped SLO, all instances        | *                    | true            | slo_instance_id: "*"       | All instances |

**Non-grouped SLO edge case**: Legacy dashboards always stored sloInstanceId: `*` for non-grouped SLOs, even though `*` is the default instance ID and doesn't imply "show all instances". The transform should use the legacy showAllGroupByInstances field to distinguish: when sloInstanceId is `*` but showAllGroupByInstances is false, slo_instance_id should be dropped from the output. This ensures non-grouped SLOs continue to render as a single card.

## Acceptance criteria

- don't include show_all_group_by_instances in the single overview schema
- **New panels**: 
  - non-grouped SLOs save slo_instance_id as undefined
  - grouped SLOs with all instances save slo_instance_id as `*`
  - grouped SLOs with a specific instance save slo_instance_id as the instance UUID
- **Legacy panels**
  - non-grouped SLOs (sloInstanceId: `*`, showAllGroupByInstances: false) render as single card
  - grouped SLOs with all instances (sloInstanceId: `*`, showAllGroupByInstances: true) render all instances
  - grouped SLOs with specific instance (sloInstanceId: <UUID>, showAllGroupByInstances: false) render single card
- Panel placement uses wide layout (width 24) only when slo_instance_id === `*` or group overview
- Legacy showAllGroupByInstances is stripped from transformed state and never reaches the schema
