### PR TITLE
apply defaultValue to overview_mode for both single and groups cases

### DIFF
--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.test.ts
@@ -128,7 +128,7 @@ describe('schema validation', () => {
       });
     });
 
-    it('should reject invalid group_by value without cross-variant slo_id error', () => {
+    it('should reject invalid group_by value with group_filters.group_by error', () => {
       const invalidState = {
         group_filters: {
           group_by: 'invalid-group-by',
@@ -139,7 +139,8 @@ describe('schema validation', () => {
       expect(() => overviewEmbeddableSchema.validate(invalidState)).toThrow(
         /group_filters\.group_by/
       );
-      expect(() => overviewEmbeddableSchema.validate(invalidState)).not.toThrow(/slo_id/);
+      // With schema.oneOf, both branches are tried and all failures are reported, so the error
+      // may also mention slo_id from the single branch; we only assert the group branch error.
     });
 
     it('should validate group overview state with minimal required fields', () => {

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.test.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.test.ts
@@ -47,17 +47,23 @@ describe('schema validation', () => {
         overview_mode: 'invalid-mode',
       };
 
-      expect(() => overviewEmbeddableSchema.validate(invalidState)).toThrow(
-        /expected "overview_mode" to be one of \["single", "groups"\]/
-      );
+      expect(() => overviewEmbeddableSchema.validate(invalidState)).toThrow();
+      const err = (() => {
+        try {
+          overviewEmbeddableSchema.validate(invalidState);
+        } catch (e) {
+          return e;
+        }
+      })();
+      expect(String(err)).toMatch(/single|groups/);
     });
 
-    it('should report missing overview_mode without cross-variant noise', () => {
+    it('should default overview_mode to "single" when slo_id is provided and overview_mode is missing', () => {
       const missingMode = { slo_id: 'test-slo-id' };
 
-      expect(() => overviewEmbeddableSchema.validate(missingMode)).toThrow(
-        /"overview_mode" property is required/
-      );
+      expect(() => overviewEmbeddableSchema.validate(missingMode)).not.toThrow();
+      const result = overviewEmbeddableSchema.validate(missingMode);
+      expect(result.overview_mode).toBe('single');
     });
   });
 
@@ -145,6 +151,18 @@ describe('schema validation', () => {
       };
 
       expect(() => overviewEmbeddableSchema.validate(minimalState)).not.toThrow();
+    });
+
+    it('should default overview_mode to "groups" when slo_id is not provided and overview_mode is missing', () => {
+      const missingMode = {
+        group_filters: {
+          group_by: 'status' as const,
+        },
+      };
+
+      expect(() => overviewEmbeddableSchema.validate(missingMode)).not.toThrow();
+      const result = overviewEmbeddableSchema.validate(missingMode);
+      expect(result.overview_mode).toBe('groups');
     });
 
     it('should validate group overview state with empty group_filters or missing group_by', () => {

--- a/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.ts
+++ b/x-pack/solutions/observability/plugins/slo/server/lib/embeddables/schema.ts
@@ -29,7 +29,12 @@ const SingleOverviewCustomSchema = schema.object({
       meta: { description: 'The name of the remote SLO' },
     })
   ),
-  overview_mode: schema.literal('single'),
+  overview_mode: schema.oneOf([schema.literal('single'), schema.literal('groups')], {
+    defaultValue: 'single',
+    meta: {
+      description: 'The mode of the overview is "single" when slo_id is provided.',
+    },
+  }),
 });
 
 const groupBySchema = schema.oneOf([
@@ -49,7 +54,13 @@ const GroupOverviewCustomSchema = schema.object({
       kql_query: schema.maybe(schema.string()),
     })
   ),
-  overview_mode: schema.literal('groups'),
+  overview_mode: schema.oneOf([schema.literal('single'), schema.literal('groups')], {
+    defaultValue: 'groups',
+    meta: {
+      description:
+        'Overview mode. Defaults to "groups" when omitted (use "single" with slo_id for a single SLO).',
+    },
+  }),
 });
 
 function getSingleOverviewEmbeddableSchema(getDrilldownsSchema: GetDrilldownsSchemaFnType) {
@@ -84,9 +95,13 @@ function getGroupOverviewEmbeddableSchema(getDrilldownsSchema: GetDrilldownsSche
   );
 }
 
+/**
+ * SLO Overview embeddable schema. overview_mode defaults to 'groups' when omitted, unless slo_id
+ * is provided (then it defaults to 'single'). Uses oneOf: single branch is tried first; if slo_id
+ * is missing that fails and the group branch is used with overview_mode default 'groups'.
+ */
 export const getOverviewEmbeddableSchema = (getDrilldownsSchema: GetDrilldownsSchemaFnType) => {
-  return schema.discriminatedUnion(
-    'overview_mode',
+  return schema.oneOf(
     [
       getSingleOverviewEmbeddableSchema(getDrilldownsSchema),
       getGroupOverviewEmbeddableSchema(getDrilldownsSchema),


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/255681

## Summary

When creating a dashboard via `POST kbn:/api/dashboards?apiVersion=1` with an `SLO_EMBEDDABLE` panel whose config is omitted `overview_mode`, validation fails with:

`[request body.panels.0.0.config]: "overview_mode" property is required`

- When `slo_id` is provided (or optionally an slo_instance_id as well), then `defaultValue` is `single`
- When `no slo_id` is provided and `no overview_mode`, then `defaultValue` is `groups`


## Acceptance criteria

- when an slo_id is provided, but no overview_mode, then defaultValue is single
- when no overview_mode and no slo_id is provided, then defaultValue is groups


| slo_id Provided | overview_mode Provided | defaultValue |
|-----------------|------------------------|--------------|
| Yes             | No                     | `single`     |
| No              | No                     | `groups`     |


## Approach

Switched from `schema.discriminatedUnion` to `schema.oneOf` so each branch can have its own `defaultValue` for `overview_mode`. 

- `getOverviewEmbeddableSchema()` returns `schema.oneOf([singleSchema, groupSchema])` with single branch first, then group.
- Single branch: `overview_mode: schema.oneOf([literal('single'), literal('groups')], { defaultValue: 'single' })`.
- Group branch: `overview_mode: schema.oneOf([literal('single'), literal('groups')], { defaultValue: 'groups' })`.
- When `overview_mode` is omitted: oneOf tries single first (defaults to 'single'); if `slo_id` is missing that fails, then group branch is used (defaults to 'groups'). So **groups is the default when omitted** unless `slo_id` is provided.


## Trade off

 Trade off is that a request like this with invalid group_by will report all failures from all branches.

```
POST kbn:/api/dashboards?apiVersion=1
{
  "title": "SLO group embeddable invalid group filters",
  "panels": [
    {
      "config": {
        "group_filters": {
            "group_by": "invalid group by"
        }
      },
      "grid": {
        "x": 1,
        "y": 0
      },
      "type": "SLO_EMBEDDABLE"
    }
  ]
}
```

```
{
  "statusCode": 400,
  "error": "Bad Request",
  "message": """[request body.panels.0]: types that failed validation:
- [request body.panels.0.0.config]: types that failed validation:
 - [request body.panels.0.config.0.slo_id]: expected value of type [string] but got [undefined]
 - [request body.panels.0.config.1.group_filters.group_by]: types that failed validation:
  - [request body.panels.0.config.group_filters.group_by.0]: expected value to equal [slo.tags]
  - [request body.panels.0.config.group_filters.group_by.1]: expected value to equal [status]
  - [request body.panels.0.config.group_filters.group_by.2]: expected value to equal [slo.indicator.type]
- [request body.panels.0.1.title]: expected value of type [string] but got [undefined]"""
}
```

