### PR TITLE
[Synthetics UI]: display remote monitors in overview management pages

### DIFF
--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_remote_badge.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_remote_badge.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiBadge, EuiFlexItem, EuiToolTip } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import type { MouseEvent } from 'react';
+import React from 'react';
+import type { RemoteMonitorInfo } from '../../../../../../common/runtime_types/remote';
+import { useKibanaSpace } from '../../../../../hooks/use_kibana_space';
+import { createRemoteMonitorDetailsUrl } from '../../../utils/remote_monitor_urls';
+
+export function MonitorRemoteBadge({
+  remote,
+  configId,
+}: {
+  remote?: RemoteMonitorInfo;
+  configId: string;
+}) {
+  const { space } = useKibanaSpace();
+
+  if (!remote) {
+    return null;
+  }
+
+  const detailsUrl = createRemoteMonitorDetailsUrl(remote, configId, space?.id);
+
+  return (
+    <EuiFlexItem grow={false}>
+      <EuiToolTip content={remote.kibanaUrl} title={remote.remoteName}>
+        <EuiBadge
+          color="default"
+          href={detailsUrl}
+          target="_blank"
+          data-test-subj="syntheticsRemoteMonitorBadge"
+          onMouseDown={(e: MouseEvent) => {
+            e.stopPropagation();
+          }}
+        >
+          {i18n.translate('xpack.synthetics.remoteBadge.label', {
+            defaultMessage: 'Remote',
+          })}
+        </EuiBadge>
+      </EuiToolTip>
+    </EuiFlexItem>
+  );
+}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_remote_callout.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/common/components/monitor_remote_callout.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { EuiButton, EuiCallOut, EuiLink } from '@elastic/eui';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n-react';
+import React from 'react';
+import type { RemoteMonitorInfo } from '../../../../../../common/runtime_types/remote';
+import { useKibanaSpace } from '../../../../../hooks/use_kibana_space';
+import { createRemoteMonitorDetailsUrl } from '../../../utils/remote_monitor_urls';
+
+export function MonitorRemoteCallout({
+  remote,
+  configId,
+}: {
+  remote: RemoteMonitorInfo;
+  configId: string;
+}) {
+  const { space } = useKibanaSpace();
+  const detailsUrl = createRemoteMonitorDetailsUrl(remote, configId, space?.id);
+
+  return (
+    <EuiCallOut
+      title={i18n.translate('xpack.synthetics.monitorDetails.remoteCallout.title', {
+        defaultMessage: 'Remote monitor',
+      })}
+      data-test-subj="syntheticsRemoteMonitorCallout"
+    >
+      <p>
+        <FormattedMessage
+          id="xpack.synthetics.monitorDetails.remoteCallout.description"
+          defaultMessage="This is a remote monitor fetched from the remote cluster: {remoteName} with Kibana URL {kibanaUrl}. Configuration changes must be made on the remote Kibana instance."
+          values={{
+            remoteName: <strong>{remote.remoteName}</strong>,
+            kibanaUrl: (
+              <EuiLink
+                data-test-subj="syntheticsRemoteMonitorCalloutKibanaLink"
+                href={remote.kibanaUrl}
+                target="_blank"
+              >
+                {remote.kibanaUrl}
+              </EuiLink>
+            ),
+          }}
+        />
+      </p>
+      {detailsUrl && (
+        <EuiButton
+          data-test-subj="syntheticsRemoteMonitorCalloutDetailsButton"
+          href={detailsUrl}
+          color="primary"
+          target="_blank"
+          iconType="external"
+          iconSide="right"
+        >
+          {i18n.translate('xpack.synthetics.monitorDetails.remoteCallout.viewButton', {
+            defaultMessage: 'View on remote instance',
+          })}
+        </EuiButton>
+      )}
+    </EuiCallOut>
+  );
+}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_remote_info.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/hooks/use_monitor_remote_info.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import type { RemoteMonitorInfo } from '../../../../../../common/runtime_types/remote';
+import { selectOverviewStatus } from '../../../state/overview_status';
+
+/**
+ * Looks up remote monitor info from the overview status state for a given configId.
+ * Returns the RemoteMonitorInfo if the monitor was fetched from a remote cluster,
+ * or undefined if it is a local monitor.
+ */
+export function useMonitorRemoteInfo(configId: string): RemoteMonitorInfo | undefined {
+  const { allConfigs } = useSelector(selectOverviewStatus);
+
+  return useMemo(() => {
+    if (!allConfigs) {
+      return undefined;
+    }
+    const match = allConfigs.find((config) => config.configId === configId);
+    return match?.remote;
+  }, [allConfigs, configId]);
+}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_page_title.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_details_page_title.tsx
@@ -7,17 +7,23 @@
 
 import React from 'react';
 import { EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+import { useParams } from 'react-router-dom';
 import { MonitorSelector } from './monitor_selector/monitor_selector';
 import { useSelectedMonitor } from './hooks/use_selected_monitor';
+import { useMonitorRemoteInfo } from './hooks/use_monitor_remote_info';
+import { MonitorRemoteBadge } from '../common/components/monitor_remote_badge';
 
 export const MonitorDetailsPageTitle = () => {
+  const { monitorId } = useParams<{ monitorId: string }>();
   const { monitor } = useSelectedMonitor();
+  const remoteInfo = useMonitorRemoteInfo(monitorId);
 
   return (
     <EuiFlexGroup gutterSize="s" alignItems="center" responsive={false}>
       <EuiFlexItem grow={false} data-test-subj="monitorNameTitle">
         {monitor?.name}
       </EuiFlexItem>
+      {remoteInfo && <MonitorRemoteBadge remote={remoteInfo} configId={monitorId} />}
       <EuiFlexItem>
         <MonitorSelector />
       </EuiFlexItem>

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitor_details/monitor_summary/monitor_summary.tsx
@@ -19,11 +19,13 @@ import { i18n } from '@kbn/i18n';
 import { useParams } from 'react-router-dom';
 import { LoadWhenInView } from '@kbn/observability-shared-plugin/public';
 import { MonitorMWsCallout } from '../../common/mws_callout/monitor_mws_callout';
+import { MonitorRemoteCallout } from '../../common/components/monitor_remote_callout';
 import { MissingIntegrationCallout } from '../../monitor_add_edit/steps/missing_integration_callout';
 import { SummaryPanel } from './summary_panel';
 
 import { useMonitorDetailsPage } from '../use_monitor_details_page';
 import { useMonitorRangeFrom } from '../hooks/use_monitor_range_from';
+import { useMonitorRemoteInfo } from '../hooks/use_monitor_remote_info';
 import { MonitorAlerts } from './monitor_alerts';
 import { MonitorStatusPanel } from '../monitor_status/monitor_status_panel';
 import { MonitorDurationTrend } from './duration_trend';
@@ -37,6 +39,7 @@ import { useMonitorAttachmentConfig } from '../hooks/use_monitor_attachment_conf
 export const MonitorSummary = () => {
   const { monitorId: configId } = useParams<{ monitorId: string }>();
   const { from, to } = useMonitorRangeFrom();
+  const remoteInfo = useMonitorRemoteInfo(configId);
 
   const dateLabel = from === 'now-30d/d' ? LAST_30_DAYS_LABEL : TO_DATE_LABEL;
   const isMediumDevice = useIsWithinBreakpoints(['xs', 's', 'm', 'l']);
@@ -52,6 +55,12 @@ export const MonitorSummary = () => {
   return (
     <>
       <MissingIntegrationCallout configId={configId} />
+      {remoteInfo && (
+        <>
+          <MonitorRemoteCallout remote={remoteInfo} configId={configId} />
+          <EuiSpacer size="m" />
+        </>
+      )}
       <MonitorPendingWrapper>
         <MonitorMWsCallout />
         <SummaryPanel dateLabel={dateLabel} from={from} to={to} />

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/actions_popover.tsx
@@ -203,6 +203,8 @@ export function ActionsPopover({
   });
 
   const alertLoading = alertStatus(monitor.configId) === FETCH_STATUS.LOADING;
+  const isRemoteMonitor = !!monitor.remote;
+
   let popoverItems: EuiContextMenuPanelItemDescriptor[] = [
     {
       name: actionsMenuGoToMonitorName,
@@ -211,121 +213,127 @@ export function ActionsPopover({
       'data-test-subj': 'actionsPopoverGoToMonitor',
     },
     quickInspectPopoverItem,
-    {
-      name: testInProgress ? (
-        <EuiToolTip content={TEST_SCHEDULED_LABEL}>
-          <span tabIndex={0}>{runTestManually}</span>
-        </EuiToolTip>
-      ) : (
-        <NoPermissionsTooltip
-          canUsePublicLocations={canUsePublicLocations}
-          canEditSynthetics={canEditSynthetics}
-        >
-          {runTestManually}
-        </NoPermissionsTooltip>
-      ),
-      icon: 'flask',
-      disabled: testInProgress || !canUsePublicLocations || !isServiceAllowed,
-      onClick: () => {
-        dispatch(manualTestMonitorAction.get({ configId: monitor.configId, name: monitor.name }));
-        dispatch(setFlyoutConfig(null));
-        setIsPopoverOpen(false);
-      },
-    },
-    {
-      name: (
-        <NoPermissionsTooltip canEditSynthetics={canEditSynthetics}>
-          {actionsMenuEditMonitorName}
-        </NoPermissionsTooltip>
-      ),
-      icon: 'pencil',
-      disabled: !canEditSynthetics || !isServiceAllowed,
-      href: editUrl,
-      'data-test-subj': 'editMonitorLink',
-    },
-    {
-      name: (
-        <NoPermissionsTooltip canEditSynthetics={canEditSynthetics}>
-          {actionsMenuCloneMonitorName}
-        </NoPermissionsTooltip>
-      ),
-      icon: 'copy',
-      disabled: !canEditSynthetics || !isServiceAllowed,
-      href: http?.basePath.prepend(`synthetics/add-monitor?cloneId=${monitor.configId}`),
-      'data-test-subj': 'cloneMonitorLink',
-    },
-    {
-      name: (
-        <NoPermissionsTooltip canEditSynthetics={canEditSynthetics}>
-          {CREATE_SLO}
-        </NoPermissionsTooltip>
-      ),
-      icon: 'chartGauge',
-      disabled: !canEditSynthetics || !isServiceAllowed,
-      onClick: () => {
-        setIsPopoverOpen(false);
-        setIsSLOFlyoutOpen(true);
-      },
-      'data-test-subj': 'createSLOBtn',
-    },
-    {
-      name: (
-        <NoPermissionsTooltip
-          canEditSynthetics={canEditSynthetics}
-          canUsePublicLocations={canUsePublicLocations}
-        >
-          {enableLabel}
-        </NoPermissionsTooltip>
-      ),
-      icon: 'contrast',
-      disabled: !canEditSynthetics || !canUsePublicLocations,
-      onClick: () => {
-        if (status !== FETCH_STATUS.LOADING) {
-          updateMonitorEnabledState(!monitor.isEnabled);
-        }
-      },
-    },
-    {
-      name: (
-        <NoPermissionsTooltip
-          canEditSynthetics={canEditSynthetics}
-          canUsePublicLocations={canUsePublicLocations}
-        >
-          {monitor.isStatusAlertEnabled ? disableAlertLabel : enableMonitorAlertLabel}
-        </NoPermissionsTooltip>
-      ),
-      disabled: !canEditSynthetics || !canUsePublicLocations || !isServiceAllowed,
-      icon: alertLoading ? (
-        <EuiLoadingSpinner size="s" />
-      ) : monitor.isStatusAlertEnabled ? (
-        'bellSlash'
-      ) : (
-        'bell'
-      ),
-      onClick: () => {
-        if (!alertLoading) {
-          updateAlertEnabledState({
-            monitor: {
-              [ConfigKey.ALERT_CONFIG]: toggleStatusAlert({
-                status: {
-                  enabled: monitor.isStatusAlertEnabled,
-                },
-              }),
+    ...(!isRemoteMonitor
+      ? ([
+          {
+            name: testInProgress ? (
+              <EuiToolTip content={TEST_SCHEDULED_LABEL}>
+                <span tabIndex={0}>{runTestManually}</span>
+              </EuiToolTip>
+            ) : (
+              <NoPermissionsTooltip
+                canUsePublicLocations={canUsePublicLocations}
+                canEditSynthetics={canEditSynthetics}
+              >
+                {runTestManually}
+              </NoPermissionsTooltip>
+            ),
+            icon: 'flask',
+            disabled: testInProgress || !canUsePublicLocations || !isServiceAllowed,
+            onClick: () => {
+              dispatch(
+                manualTestMonitorAction.get({ configId: monitor.configId, name: monitor.name })
+              );
+              dispatch(setFlyoutConfig(null));
+              setIsPopoverOpen(false);
             },
-            configId: monitor.configId,
-            name: monitor.name,
-          });
-        }
-      },
-    },
-    {
-      name: addMonitorToDashboardLabel,
-      icon: 'dashboardApp',
-      onClick: () => {
-        setIsPopoverOpen(false);
-        setDashboardAttachmentReady(true);
-      },
-    },
+          },
+          {
+            name: (
+              <NoPermissionsTooltip canEditSynthetics={canEditSynthetics}>
+                {actionsMenuEditMonitorName}
+              </NoPermissionsTooltip>
+            ),
+            icon: 'pencil',
+            disabled: !canEditSynthetics || !isServiceAllowed,
+            href: editUrl,
+            'data-test-subj': 'editMonitorLink',
+          },
+          {
+            name: (
+              <NoPermissionsTooltip canEditSynthetics={canEditSynthetics}>
+                {actionsMenuCloneMonitorName}
+              </NoPermissionsTooltip>
+            ),
+            icon: 'copy',
+            disabled: !canEditSynthetics || !isServiceAllowed,
+            href: http?.basePath.prepend(`synthetics/add-monitor?cloneId=${monitor.configId}`),
+            'data-test-subj': 'cloneMonitorLink',
+          },
+          {
+            name: (
+              <NoPermissionsTooltip canEditSynthetics={canEditSynthetics}>
+                {CREATE_SLO}
+              </NoPermissionsTooltip>
+            ),
+            icon: 'chartGauge',
+            disabled: !canEditSynthetics || !isServiceAllowed,
+            onClick: () => {
+              setIsPopoverOpen(false);
+              setIsSLOFlyoutOpen(true);
+            },
+            'data-test-subj': 'createSLOBtn',
+          },
+          {
+            name: (
+              <NoPermissionsTooltip
+                canEditSynthetics={canEditSynthetics}
+                canUsePublicLocations={canUsePublicLocations}
+              >
+                {enableLabel}
+              </NoPermissionsTooltip>
+            ),
+            icon: 'contrast',
+            disabled: !canEditSynthetics || !canUsePublicLocations,
+            onClick: () => {
+              if (status !== FETCH_STATUS.LOADING) {
+                updateMonitorEnabledState(!monitor.isEnabled);
+              }
+            },
+          },
+          {
+            name: (
+              <NoPermissionsTooltip
+                canEditSynthetics={canEditSynthetics}
+                canUsePublicLocations={canUsePublicLocations}
+              >
+                {monitor.isStatusAlertEnabled ? disableAlertLabel : enableMonitorAlertLabel}
+              </NoPermissionsTooltip>
+            ),
+            disabled: !canEditSynthetics || !canUsePublicLocations || !isServiceAllowed,
+            icon: alertLoading ? (
+              <EuiLoadingSpinner size="s" />
+            ) : monitor.isStatusAlertEnabled ? (
+              'bellSlash'
+            ) : (
+              'bell'
+            ),
+            onClick: () => {
+              if (!alertLoading) {
+                updateAlertEnabledState({
+                  monitor: {
+                    [ConfigKey.ALERT_CONFIG]: toggleStatusAlert({
+                      status: {
+                        enabled: monitor.isStatusAlertEnabled,
+                      },
+                    }),
+                  },
+                  configId: monitor.configId,
+                  name: monitor.name,
+                });
+              }
+            },
+          },
+          {
+            name: addMonitorToDashboardLabel,
+            icon: 'dashboardApp',
+            onClick: () => {
+              setIsPopoverOpen(false);
+              setDashboardAttachmentReady(true);
+            },
+          },
+        ] as EuiContextMenuPanelItemDescriptor[])
+      : []),
   ];
   if (isInspectView) popoverItems = popoverItems.filter((i) => i !== quickInspectPopoverItem);
 

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/hooks/use_monitors_table_columns.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/compact_view/hooks/use_monitors_table_columns.tsx
@@ -19,6 +19,7 @@ import { MonitorBarSeries } from '../components/monitor_bar_series';
 import { useMonitorHistogram } from '../../../../hooks/use_monitor_histogram';
 import type { OverviewStatusMetaData } from '../../../../../../../../../common/runtime_types';
 import { MonitorTypeBadge } from '../../../../../common/components/monitor_type_badge';
+import { MonitorRemoteBadge } from '../../../../../common/components/monitor_remote_badge';
 import { getFilterForTypeMessage } from '../../../../management/monitor_list_table/labels';
 import type { FlyoutParamProps } from '../../types';
 import { MonitorsActions } from '../components/monitors_actions';
@@ -104,9 +105,16 @@ export const useMonitorsTableColumns = ({
             className="clickCellContent"
           >
             <EuiFlexItem>
-              <EuiText size="s" onClick={() => openFlyout(monitor)}>
-                {name}
-              </EuiText>
+              <EuiFlexGroup alignItems="center" gutterSize="xs" responsive={false}>
+                <EuiFlexItem grow={false}>
+                  <EuiText size="s" onClick={() => openFlyout(monitor)}>
+                    {name}
+                  </EuiText>
+                </EuiFlexItem>
+                {monitor.remote && (
+                  <MonitorRemoteBadge remote={monitor.remote} configId={monitor.configId} />
+                )}
+              </EuiFlexGroup>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
               <MonitorTypeBadge

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_item_body.tsx
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/components/monitors_page/overview/overview/metric_item/metric_item_body.tsx
@@ -8,8 +8,9 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { TagsList } from '@kbn/observability-shared-plugin/public';
-import { EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import { MonitorTypeBadge } from '../../../../common/components/monitor_type_badge';
+import { MonitorRemoteBadge } from '../../../../common/components/monitor_remote_badge';
 import * as labels from '../../../management/monitor_list_table/labels';
 import type { OverviewStatusMetaData } from '../../../../../../../../common/runtime_types';
 
@@ -28,11 +29,21 @@ export const MetricItemBody = ({ monitor }: { monitor: OverviewStatusMetaData })
       }}
     />
   );
+
+  const badges = (
+    <>
+      <EuiFlexItem grow={false}>{typeBadge}</EuiFlexItem>
+      {monitor.remote && <MonitorRemoteBadge remote={monitor.remote} configId={monitor.configId} />}
+    </>
+  );
+
   if (tags.length === 0) {
     return (
       <>
         <EuiSpacer size="xs" />
-        {typeBadge}
+        <EuiFlexGroup gutterSize="xs" alignItems="center" responsive={false} wrap>
+          {badges}
+        </EuiFlexGroup>
       </>
     );
   }
@@ -42,7 +53,7 @@ export const MetricItemBody = ({ monitor }: { monitor: OverviewStatusMetaData })
       <EuiSpacer size="xs" />
       {(tags ?? []).length > 0 && (
         <TagsList
-          prependChildren={<EuiFlexItem grow={false}>{typeBadge}</EuiFlexItem>}
+          prependChildren={badges}
           color="default"
           tags={tags}
           disableExpand={true}

--- a/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/remote_monitor_urls.ts
+++ b/x-pack/solutions/observability/plugins/synthetics/public/apps/synthetics/utils/remote_monitor_urls.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import type { RemoteMonitorInfo } from '../../../../common/runtime_types/remote';
+
+/**
+ * Builds a base URL for a remote monitor details page on the remote Kibana instance.
+ */
+function createBaseRemoteMonitorDetailsUrl(
+  remote: RemoteMonitorInfo,
+  configId: string,
+  spaceId: string = 'default'
+): URL | undefined {
+  if (!remote || remote.kibanaUrl === '') {
+    return undefined;
+  }
+
+  const spacePath = spaceId !== 'default' ? `/s/${spaceId}` : '';
+  const detailsPath = `/app/synthetics/monitor/${configId}`;
+
+  return new URL(`${spacePath}${detailsPath}`, remote.kibanaUrl);
+}
+
+/**
+ * Creates a URL string for viewing a remote monitor's details page on the remote Kibana instance.
+ */
+export function createRemoteMonitorDetailsUrl(
+  remote: RemoteMonitorInfo,
+  configId: string,
+  spaceId: string = 'default'
+): string | undefined {
+  return createBaseRemoteMonitorDetailsUrl(remote, configId, spaceId)?.toString();
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/kibana/issues/259271

<img width="500" height="633" alt="Screenshot 2026-04-11 at 23 16 11" src="https://github.com/user-attachments/assets/8fb71ce9-2eea-4485-b5d4-06cae16fb81e" />

**Note**
Rebase once Schema and backend changes [PR](https://github.com/elastic/kibana/pull/262497) is merged